### PR TITLE
Add smart defaults for the puppet_data_service::database_host parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ mod 'puppet_data_service',
   branch: 'main'
 ```
 
-2. Include the [PDS Hiera level](#hiera-backend) in your control-repo's `hiera.yaml` file
+1. Include the [PDS Hiera level](#hiera-backend) in your control-repo's `hiera.yaml` file
 
 ## Usage
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,4 +3,4 @@ lookup_options:
   puppet_data_service::server::pds_token:
     convert_to: "Sensitive"
 
-puppet_data_service::server::package_source: 'https://github.com/puppetlabs/puppet-data-service/releases/download/v0.1.0/pds-server-0.1.0-1.x86_64.pe-2021.4.0.rpm'
+puppet_data_service::server::package_source: 'https://github.com/puppetlabs/puppet-data-service/releases/download/v0.1.1/pds-server-0.1.1-1.pe.2021.5.0.el7.x86_64.rpm'

--- a/lib/puppet/functions/puppet_data_service/data_hash.rb
+++ b/lib/puppet/functions/puppet_data_service/data_hash.rb
@@ -3,12 +3,11 @@ require 'yaml'
 require 'net/http'
 
 Puppet::Functions.create_function(:'puppet_data_service::data_hash') do
-
   # Used for raising an error to connect to the PDS service
   class PDSConnectionError < StandardError; end
 
-  DEFAULT_CONFIG_PATH = '/etc/puppetlabs/pds/pds-client.yaml'
-  DEFAULT_ON_CONFIG_ABSENT = 'fail' # other valid value is 'continue'
+  DEFAULT_CONFIG_PATH = '/etc/puppetlabs/pds/pds-client.yaml'.freeze
+  DEFAULT_ON_CONFIG_ABSENT = 'fail'.freeze # other valid value is 'continue'
 
   dispatch :data_hash do
     param 'Hash', :options
@@ -93,12 +92,10 @@ Puppet::Functions.create_function(:'puppet_data_service::data_hash') do
     opts = parse_options(options)
 
     if [opts[:token], opts[:servers]].any? { |val| val.nil? }
-      if opts[:on_absent] == 'fail'
-        raise Puppet::DataBinding::LookupError, "Config file does not exist and config not provided in options; configured action is to fail"
-      else
-        context.explain { "[puppet_data_service::data_hash] Required config absent; configured action is to continue" }
-        context.not_found
-      end
+      raise Puppet::DataBinding::LookupError, 'Config file does not exist and config not provided in options; configured action is to fail' if opts[:on_absent] == 'fail'
+
+      context.explain { '[puppet_data_service::data_hash] Required config absent; configured action is to continue' }
+      context.not_found
     end
 
     adapter = sessionadapter.adapt(closure_scope.environment)
@@ -121,22 +118,19 @@ Puppet::Functions.create_function(:'puppet_data_service::data_hash') do
     uri = URI::HTTPS.build(host: session.address,
                            port: session.port,
                            path: '/v1/hiera-data',
-                           query: URI.encode_www_form({level: opts[:level]}))
+                           query: URI.encode_www_form({ level: opts[:level] }))
 
     req = Net::HTTP::Get.new(uri)
-    req['Content-Type'] = "application/json"
+    req['Content-Type'] = 'application/json'
     req['Authorization'] = "Bearer #{opts[:token]}"
 
     response = session.request(req)
 
-    if response.is_a?(Net::HTTPOK)
-      data = JSON.parse(response.body)
-      data.reduce({}) do |memo, datum|
-        memo[datum['key']] = datum['value']
-        memo
-      end
-    else
-      raise Puppet::DataBinding::LookupError, "Invalid response from PDS server: #{response.class}: #{response.body}"
+    raise Puppet::DataBinding::LookupError, "Invalid response from PDS server: #{response.class}: #{response.body}" unless response.is_a?(Net::HTTPOK)
+
+    data = JSON.parse(response.body)
+    data.each_with_object({}) do |datum, memo|
+      memo[datum['key']] = datum['value']
     end
   end
 end

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -1,3 +1,4 @@
+# Configuration of the database server
 class puppet_data_service::database (
   Optional[Array[String]] $allowlist = undef,
 ) {
@@ -24,7 +25,7 @@ class puppet_data_service::database (
 
   pe_postgresql_psql { 'ROLE pds':
     unless  => "SELECT FROM pg_roles WHERE rolname = 'pds'",
-    command => "CREATE ROLE pds WITH LOGIN CONNECTION LIMIT -1",
+    command => 'CREATE ROLE pds WITH LOGIN CONNECTION LIMIT -1',
     before  => Pe_postgresql_psql['DATABASE pds'],
   }
 
@@ -43,13 +44,13 @@ class puppet_data_service::database (
 
   pe_postgresql_psql { 'DATABASE pds':
     unless  => "SELECT datname FROM pg_database WHERE datname='pds'",
-    command => "CREATE DATABASE pds TABLESPACE pds",
+    command => 'CREATE DATABASE pds TABLESPACE pds',
   }
 
   pe_postgresql_psql { 'DATABASE pds EXTENSION pgcrypto':
     db      => 'pds',
     unless  => "SELECT FROM pg_extension WHERE extname = 'pgcrypto'",
-    command => "CREATE EXTENSION pgcrypto",
+    command => 'CREATE EXTENSION pgcrypto',
     require => Pe_postgresql_psql['DATABASE pds'],
     before  => Class['puppet_data_service::anchor'],
   }
@@ -67,14 +68,14 @@ class puppet_data_service::database (
     notify      => Exec['postgresql_reload'],
   }
 
-  pe_postgresql::server::pg_hba_rule { "pds access for mapped certnames (ipv4)":
-    auth_option => "map=pds-map clientcert=1",
+  pe_postgresql::server::pg_hba_rule { 'pds access for mapped certnames (ipv4)':
+    auth_option => 'map=pds-map clientcert=1',
     address     => '0.0.0.0/0',
     order       => '4',
   }
 
-  pe_postgresql::server::pg_hba_rule { "pds access for mapped certnames (ipv6)":
-    auth_option => "map=pds-map clientcert=1",
+  pe_postgresql::server::pg_hba_rule { 'pds access for mapped certnames (ipv6)':
+    auth_option => 'map=pds-map clientcert=1',
     address     => '::/0',
     order       => '5',
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,6 +1,6 @@
 class puppet_data_service::server (
   Sensitive[String] $pds_token,
-  String            $database_host = undef,
+  Optional[String]  $database_host = undef,
   Optional[String]  $package_source = undef,
   Boolean           $manage_trusted_external_command_setting = true,
 ) {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,3 +1,4 @@
+# Configuration of the PDS server
 class puppet_data_service::server (
   Sensitive[String] $pds_token,
   Optional[String]  $database_host = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -60,7 +60,7 @@ class puppet_data_service::server (
       group   => 'pe-puppet',
       mode    => '0640',
       content => to_yaml({
-        'baseuri' => "https://${database_host}:8160/v1",
+        'baseuri' => "https://${db_host}:8160/v1",
         'token'   => $pds_token.unwrap,
         'ca-file' => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
       }),

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -44,8 +44,9 @@ class puppet_data_service::server (
   if $database_host != undef {
     $db_host = $database_host
   } else {
-    # query PuppetDB for the database host
-    $query_output = puppetdb_query('nodes[certname] { resources{type="Class" and title="Puppet_enterprise::Profile::Database"}}')
+    # query PuppetDB for the primary server since we assume the database runs on it
+    # in cases this guess is wrong, the user will need to override the $database_host parameter explicitly.
+    $query_output = puppetdb_query('resources[certname] {type="Class" and title="Puppet_enterprise::Profile::Certificate_authority"}')
     if empty($query_output) {
       # not found in PuppetDB, use fact
       $db_host = $facts['clientcert']


### PR DESCRIPTION
This PR adds smart defaults for the puppet_data_service::database_host parameter

To verify that it works, you can login to https://dbttst10-puppet.se.automationdemos.com/
