### PR TITLE
uses the clientcert for the PDS server baseURI config

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,4 +3,4 @@ lookup_options:
   puppet_data_service::server::pds_token:
     convert_to: "Sensitive"
 
-puppet_data_service::server::package_source: 'https://github.com/puppetlabs/puppet-data-service/releases/download/v0.1.1/pds-server-0.1.1-1.pe.2021.5.0.el7.x86_64.rpm'
+puppet_data_service::server::package_source: 'https://github.com/puppetlabs/puppet-data-service/releases/download/v0.1.2/pds-server-0.1.2-1.pe.2021.5.0.el7.x86_64.rpm'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -62,7 +62,7 @@ class puppet_data_service::server (
       group   => 'pe-puppet',
       mode    => '0640',
       content => to_yaml({
-        'baseuri' => "https://${db_host}:8160/v1",
+        'baseuri' => "https://${clientcert}:8160/v1",
         'token'   => $pds_token.unwrap,
         'ca-file' => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
       }),

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -92,7 +92,6 @@ class puppet_data_service::server (
     },
 
     exec { 'pds-migrations':
-      unless  => '/opt/puppetlabs/sbin/pds-ctl rake db:migrate:status',
       command => Sensitive(@("CMD"/L)),
         /usr/bin/test "$(/opt/puppetlabs/sbin/pds-ctl rake db:version | cut -d ':' -f 2)" -eq 0 && \
         /opt/puppetlabs/sbin/pds-ctl rake db:migrate && \

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -100,7 +100,7 @@ class puppet_data_service::server (
     },
 
     exec { 'pds-set-admin-user':
-      unless  => '/opt/puppetlabs/sbin/pds-ctl rake app:does_admin_exist',
+      unless  => '/opt/puppetlabs/sbin/pds-ctl rake app:does_admin_exist?',
       command => Sensitive(@("CMD"/L)),
         /opt/puppetlabs/sbin/pds-ctl rake 'app:set_admin_token[${pds_token.unwrap}]'
         | CMD

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -92,6 +92,7 @@ class puppet_data_service::server (
     },
 
     exec { 'pds-migrations':
+      unless  => '/opt/puppetlabs/sbin/pds-ctl rake db:migrate:status',
       command => Sensitive(@("CMD"/L)),
         /usr/bin/test "$(/opt/puppetlabs/sbin/pds-ctl rake db:version | cut -d ':' -f 2)" -eq 0 && \
         /opt/puppetlabs/sbin/pds-ctl rake db:migrate

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -101,7 +101,7 @@ class puppet_data_service::server (
     },
 
     exec { 'pds-set-admin-user':
-      unless  => '/opt/puppetlabs/sbin/pds-ctl rake app:does_admin_exist?',
+      unless  => '/opt/puppetlabs/sbin/pds-ctl rake app:admin_exists?',
       command => Sensitive(@("CMD"/L)),
         /opt/puppetlabs/sbin/pds-ctl rake 'app:set_admin_token[${pds_token.unwrap}]'
         | CMD


### PR DESCRIPTION
### Changes

Changing the `baseuri` configuration to avoid issues in the case where the _User_ wants to install the PDS service using another PostgreSQL instance, different than the PE primary server.

I'm also removing the `unless` restriction in the `db:migrate` exec block since it was preventing the PDS token update from the PE console